### PR TITLE
add optional heartbeat boolean

### DIFF
--- a/server.py
+++ b/server.py
@@ -76,6 +76,7 @@ def validate():
     })
 
     s = Schema({
+        Optional('heartbeat'): bool,
         Required('type'): "uk.gov.ons.edc.eq:surveyresponse",
         Required('version'): "0.0.1",
         Optional('tx_id'): All(str, ValidSurveyTxId),


### PR DESCRIPTION
**Changes**
Add option heartbeat json atrribute to the schema

**How to test**
Using postman, send survey json containing **"heartbeat": true/ false** or without and it should be validate.
Send **"heartbeat": "abc" or 123** and it should be invalid
Can also use sdx-console to do the above.

**Who can test**
Anyone but @elliott-jenkins
