### PR TITLE
configurable logging level

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 LOGGING_FORMAT = "%(asctime)s|%(levelname)s: sdx-validate: %(message)s"
-LOGGING_LEVEL = logging.DEBUG
+LOGGING_LEVEL = logging.getLevelName(os.getenv('LOGGING_LEVEL', 'DEBUG'))


### PR DESCRIPTION
**Changes**
Enables the logging level to be set by an environment variable

**How to test**
Should work the same by default
Set environment variable to a valid logging level

**Who can test**
Anyone but @elliott-jenkins
