### PR TITLE
Add optional paradata element to the schema

### DIFF
--- a/server.py
+++ b/server.py
@@ -125,7 +125,7 @@ def validate():
         schema(json_data)
 
     except MultipleInvalid as e:
-        return client_error(repr(e))
+        return client_error(str(e))
 
     except Exception as e:
         return server_error(e)

--- a/server.py
+++ b/server.py
@@ -109,7 +109,8 @@ def validate():
         Required('submitted_at'): Timestamp,
         Required('collection'): collection_s,
         Required('metadata'): metadata_s,
-        Required('data'): ValidSurveyData
+        Required('data'): ValidSurveyData,
+        Optional('paradata'): object
     })
 
     try:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -40,7 +40,8 @@ class TestValidateService(unittest.TestCase):
          "21": "60000",
          "27": "7400",
          "146": "some comment"
-       }
+       },
+       "paradata": {}
     }'''
 
     def setUp(self):


### PR DESCRIPTION
**Changes**
Enables submissions to pass validation when the optional paradata element is present

**How to test**
- Submit a survey response containing `"paradata": {}` at the top level and verify it passes validation
- Submit a survey without the paradata element to verify it still works
