### PR TITLE
Release/v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+
+### 1.5.0 2017-05-04
   - Support 'flushed' flag in schema definitions. Maintain backwards compatibility with older schema versions.
   - Validate ids based on schema
   - Validate data for different survey types

--- a/server.py
+++ b/server.py
@@ -8,7 +8,7 @@ from structlog import wrap_logger
 import os
 from uuid import UUID
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 app = Flask(__name__)
 


### PR DESCRIPTION
 - Support 'flushed' flag in schema definitions. Maintain backwards compatibility with older schema versions.
  - Validate ids based on schema
  - Validate data for different survey types
  - Support 'completed' flag in schema definitions. See the [schema definitions](https://github.com/ONSdigital/ons-schema-definitions/blob/master/docs/electronic_questionnaire_to_data_exchange.rst) for more information.
