### PR TITLE
Preparing for MCI refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Add codacy badge
   - Adding sdx-common functionality
   - Updating logger format using sdx-common
+  - Prepare for MCI refresh
 
 ### 1.5.0 2017-05-04
   - Support 'flushed' flag in schema definitions. Maintain backwards compatibility with older schema versions.

--- a/server.py
+++ b/server.py
@@ -24,7 +24,6 @@ KNOWN_SURVEYS = {
         '134': ['0005'],
         '139': ['0001'],
         '144': ['0001'],
-        'mci': ['refresh'],
     },
     '0.0.2': {
         'census': ['household', 'individual', 'communal']
@@ -163,7 +162,7 @@ def get_schema(version):
         collection_s = Schema({
             Required('period'): str,
             Required('exercise_sid'): str,
-            Required('instrument_id'): All(str, Length(max=7))  # TODO put back to 4 once EQ confirm name for mci-refresh.json
+            Required('instrument_id'): All(str, Length(max=4))
         })
 
         metadata_s = Schema({


### PR DESCRIPTION
Reverting the changes made for https://github.com/ONSdigital/sdx-validate/pull/41 now we're ready for the MCI refresh