### PR TITLE
Remove SDX_HOME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
 python:
+    - "3.6"
     - "3.5"
     - "3.4"
-before_install:
-    - git clone https://github.com/ONSdigital/sdx-common.git
-    - pip3 install ./sdx-common
 install:
-    - pip install -r requirements.txt
+    - make clean
+    - make build
     - pip install codecov
 script:
     - make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Change all instances of ADD to COPY in Dockerfile
+  - Remove use of SDX_HOME variable in makefile
 
 ### 1.7.0 2017-07-10
   - Update and pin version of sdx-common to 0.7.0

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,12 @@
-dev: check-env
-	if pip list | grep sdx-common; \
-	then \
-		cd .. && pip3 uninstall -y sdx-common && pip3 install -I ./sdx-common; \
-	else \
-		cd .. && pip3 install -I ./sdx-common; \
-	fi;
-
-	pip3 install -r requirements.txt
-	
 build:
+	git clone -b 0.7.0 https://github.com/ONSdigital/sdx-common.git
+	pip install ./sdx-common
 	pip3 install -r requirements.txt
+	rm -rf sdx-common
 
 test:
 	flake8 --exclude lib
 	python3 -m unittest tests/*.py
 
-check-env:
-ifeq ($(SDX_HOME),)
-	$(error SDX_HOME is not set)
-endif
+clean:
+	rm -rf sdx-common


### PR DESCRIPTION
## What? and Why?
SDX_HOME is not required. However currently build breaks if it's not supplied

Cherry picks from and supersedes #53 