### PR TITLE
Feature/catch key errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
   - Change all instances of ADD to COPY in Dockerfile
   - Remove use of SDX_HOME variable in makefile
+  - Missing or blank survey ids now return a 400 rather than 500
 
 ### 1.7.0 2017-07-10
   - Update and pin version of sdx-common to 0.7.0

--- a/server.py
+++ b/server.py
@@ -129,7 +129,7 @@ def validate():
         bound_logger.debug("Validating json against schema")
         schema(json_data)
 
-        survey_id = json_data['survey_id']
+        survey_id = json_data.get('survey_id')
         if survey_id not in KNOWN_SURVEYS[version]:
             return client_error("Unsupported survey '%s'" % survey_id)
 
@@ -137,7 +137,7 @@ def validate():
         if instrument_id not in KNOWN_SURVEYS[version][survey_id]:
             return client_error("Unsupported instrument '%s'" % instrument_id)
 
-    except MultipleInvalid as e:
+    except (MultipleInvalid, KeyError) as e:
         return client_error(str(e))
 
     except Exception as e:

--- a/server.py
+++ b/server.py
@@ -131,16 +131,20 @@ def validate():
 
         survey_id = json_data.get('survey_id')
         if survey_id not in KNOWN_SURVEYS[version]:
+            bound_logger.debug("Survey id is not known", survey_id=survey_id)
             return client_error("Unsupported survey '%s'" % survey_id)
 
         instrument_id = json_data['collection']['instrument_id']
         if instrument_id not in KNOWN_SURVEYS[version][survey_id]:
+            bound_logger.debug("Instrument ID is not known", survey_id=survey_id)
             return client_error("Unsupported instrument '%s'" % instrument_id)
 
     except (MultipleInvalid, KeyError) as e:
+        logger.error("Client error", error=e)
         return client_error(str(e))
 
     except Exception as e:
+        logger.error("Server error", error=e)
         return server_error(e)
 
     metadata = json_data['metadata']

--- a/server.py
+++ b/server.py
@@ -107,11 +107,6 @@ def server_error(e):
 
 @app.route('/validate', methods=['POST'])
 def validate():
-    request.get_data()
-
-    if not request.data:
-        return client_error("Request payload was empty")
-
     try:
         json_data = request.get_json(force=True)
 
@@ -139,10 +134,9 @@ def validate():
             bound_logger.debug("Instrument ID is not known", survey_id=survey_id)
             return client_error("Unsupported instrument '%s'" % instrument_id)
 
-    except (MultipleInvalid, KeyError) as e:
+    except (MultipleInvalid, KeyError, TypeError) as e:
         logger.error("Client error", error=e)
         return client_error(str(e))
-
     except Exception as e:
         logger.error("Server error", error=e)
         return server_error(e)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -94,6 +94,7 @@ class TestValidateService(unittest.TestCase):
         actual_response = self.validate_response(data)
 
         self.assertEqual(actual_response['valid'], False)
+        self.assertEqual(actual_response['status'], 400)
 
     def assertValid(self, data):
         actual_response = self.validate_response(data)
@@ -128,6 +129,18 @@ class TestValidateService(unittest.TestCase):
     def test_unknown_survey_invalid(self):
         unknown_survey = json.loads(self.message['0.0.1'])
         unknown_survey['survey_id'] = "025"
+
+        self.assertInvalid(unknown_survey)
+
+    def test_blank_survey_invalid(self):
+        unknown_survey = json.loads(self.message['0.0.1'])
+        unknown_survey['survey_id'] = ""
+
+        self.assertInvalid(unknown_survey)
+
+    def test_missing_survey_invalid(self):
+        unknown_survey = json.loads(self.message['0.0.1'])
+        del unknown_survey['survey_id']
 
         self.assertInvalid(unknown_survey)
 
@@ -201,11 +214,21 @@ class TestValidateService(unittest.TestCase):
 
         self.assertInvalid(data)
 
-    def test_census_string_data_invalid(self):
-        data = json.loads(self.message['0.0.2'])
+    def test_string_data_invalid(self):
         data = "abcd"
 
         self.assertInvalid(data)
+
+    def test_no_data(self):
+        data = None
+
+        self.assertInvalid(data)
+
+    def test_server_error(self):
+        r = self.app.post(self.validate_endpoint, data=None)
+        actual_response = json.loads(r.data.decode('UTF8'))
+        self.assertEqual(actual_response['valid'], False)
+        self.assertEqual(actual_response['status'], 500)
 
     def test_census_binary_data_error(self):
         data = json.loads(self.message['0.0.2'])


### PR DESCRIPTION
## What? and Why?
If the survey id is missing or blank then return a 400 rather than a 500. A 500 is a retry-able error and hence the message will end up endlessly nacking around the system. 

## Checklist
  - CHANGELOG.md updated? (if required)
