### PR TITLE
remove support for heartbeat survey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Remove support for heartbeat survey
   - Add /info healthcheck endpoint
 
 ### 1.12.0 2017-11-21

--- a/server.py
+++ b/server.py
@@ -189,7 +189,6 @@ def get_schema(version):
         })
 
         schema = Schema({
-            Optional('heartbeat'): bool,
             Required('type'): "uk.gov.ons.edc.eq:surveyresponse",
             Required('version'): "0.0.1",
             Optional('tx_id'): All(str, ValidSurveyTxId),
@@ -220,7 +219,6 @@ def get_schema(version):
         })
 
         schema = Schema({
-            Optional('heartbeat'): bool,
             Required('type'): "uk.gov.ons.edc.eq:surveyresponse",
             Required('version'): "0.0.2",
             Optional('tx_id'): All(str, ValidSurveyTxId),
@@ -245,7 +243,6 @@ def get_schema(version):
         })
 
         schema = Schema({
-            Optional('heartbeat'): bool,
             Required('type'): "uk.gov.ons.edc.eq:feedback",
             Optional('tx_id'): All(str, ValidSurveyTxId),
             Required('origin'): "uk.gov.ons.edc.eq",


### PR DESCRIPTION
## What? and Why?
> Removes support for heartbeat survey which was not used and would cause production issues if it was as there was no destination folder on the ftp server

## Checklist
  - CHANGELOG.md  
