### PR TITLE
Changes to handle lms2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ### Unreleased
+ - Added support for LMS 2.
+ - Made case_ref optional for version 0.0.2 surveys
 
 ### 2.5.0 2018-09-11
  - Add support for QCAS

--- a/server.py
+++ b/server.py
@@ -57,7 +57,7 @@ KNOWN_SURVEYS = {
     },
     "0.0.2": {
         "census": ["household", "individual", "communal"],
-        "lms": ["1"]
+        "lms": ["1", "2"]
     },
 }
 
@@ -271,7 +271,7 @@ def get_schema(version):
                 Optional("started_at"): Timestamp,
                 Required("submitted_at"): Timestamp,
                 Required("case_id"): str,
-                Required("case_ref"): str,
+                Optional("case_ref"): str,
                 Required("collection"): collection_s,
                 Required("metadata"): metadata_s,
                 Required("data"): ValidateListSurveyData,


### PR DESCRIPTION
## What? and Why?
Needed to handle lms 2.  Also, lms_2 doesn't have a case ref passed down so we're making it optional for 0.0.2 surveys.

## Checklist
  - CHANGELOG.md updated? (if required)
