### PR TITLE
Fail validation if response contains null characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Validate submission for null characters  (`\u0000`) and fail validation if present
 
 ### 2.12.0 2019-11-25
  - Add E-commerce formtypes 0001 and 0002

--- a/server.py
+++ b/server.py
@@ -157,7 +157,7 @@ def validate():
                 if json_data['version'] == '0.0.1':
                     for value in json_data['data'].values():
                         if r'\u0000' in str(value):
-                            bound_logger.debug("Null character found in submission")
+                            bound_logger.error("Null character found in submission")
                             return client_error("Null character found in submission", contains_null_character=True)
 
         else:
@@ -168,7 +168,7 @@ def validate():
             schema(json_data)
 
             if r'\u0000' in str(json_data['data']['message']):
-                bound_logger.debug("Null character found in feedback")
+                bound_logger.error("Null character found in feedback")
                 return client_error("Null character found in feedback", contains_null_character=True)
 
         bound_logger.debug("Success")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -401,7 +401,7 @@ class TestValidateService(unittest.TestCase):
     def test_submission_with_null_character(self):
         """Tests for the decoded version of the null character in the submission (\u0000)"""
         message = json.loads(self.message['0.0.1'])
-        message['data']['146'] = 'This is a comment with a null character\\u0000'
+        message['data']['146'] = r'This is a comment with a null character \u0000'
         response = self.validate_response(message)
 
         self.assertEqual(response['valid'], False)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -127,6 +127,7 @@ class TestValidateService(unittest.TestCase):
         actual_response = self.validate_response(data)
 
         self.assertEqual(actual_response['valid'], False)
+        self.assertNotIn('contains_null_character', actual_response)
         self.assertEqual(actual_response['status'], 400)
 
     def assertValid(self, data):
@@ -396,3 +397,13 @@ class TestValidateService(unittest.TestCase):
         survey['collection']['instrument_id'] = "1"
 
         self.assertValid(survey)
+
+    def test_submission_with_null_character(self):
+        """Tests for the decoded version of the null character in the submission (\u0000)"""
+        message = json.loads(self.message['0.0.1'])
+        message['data']['146'] = 'This is a comment with a null character\\u0000'
+        response = self.validate_response(message)
+
+        self.assertEqual(response['valid'], False)
+        self.assertEqual(response['contains_null_character'], True)
+        self.assertEqual(response['status'], 400)


### PR DESCRIPTION
## What? and Why?
If a submission had a null character in it, it would fail to save to store, get put back on the queue, then loop infinitely.
This PR makes it so that if there is a null character in a submission data (feedback and 1.0.0) then it fails validation and returns a flag to indicate the reason why it's failed

## Checklist
  - [x] CHANGELOG.md updated? (if required)
